### PR TITLE
OPS-59: use ctc modified maps directions package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11235,9 +11235,8 @@
       "from": "github:expo/react-native-maps#v0.22.1-exp.0"
     },
     "react-native-maps-directions": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/react-native-maps-directions/-/react-native-maps-directions-1.7.0.tgz",
-      "integrity": "sha512-mnLSJ2bD+esIGGN5xE9QXn3RW3C9hIRMU9ydYvSpVpnux81Q40EeI3wE/7j83CAKdm3zvVpOn8bvMv5wJiEj2Q==",
+      "version": "https://github.com/CodetheChangeFoundation/react-native-maps-directions/tarball/master",
+      "integrity": "sha512-VP9o7+piP1lWREJ+JMVXL4JN1pXqXRrcHYoYNlzx8imIU/jqMRUOEMH+4PpjBObdQ6GjMcnS1AIMR2OPj2GyDA==",
       "requires": {
         "lodash.isequal": "^4.5.0",
         "prop-types": "^15.6.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "react-native": "https://github.com/expo/react-native/archive/sdk-32.0.0.tar.gz",
     "react-native-elements": "^1.1.0",
     "react-native-google-places-autocomplete": "^1.3.9",
-    "react-native-maps-directions": "^1.7.0",
+    "react-native-maps-directions": "https://github.com/CodetheChangeFoundation/react-native-maps-directions/tarball/master",
     "react-native-snap-carousel": "^3.8.0",
     "react-native-toaster": "^1.2.2",
     "react-navigation": "^3.8.1"


### PR DESCRIPTION
### Issue
* react-native-maps-directions doesn't get turn by turn instructions by default. I directly made the change in the node module folder, but it was only there for me (i.e. no one else would see the turn by turn directions)
### Solution
* Forked the react-native-maps-directions package to ctc github and made the changes there
  * https://github.com/CodetheChangeFoundation/react-native-maps-directions
* Installed the modified repo as an npm package